### PR TITLE
city-2 background position should be different from plain .route > li

### DIFF
--- a/web/static/css/m4a.css
+++ b/web/static/css/m4a.css
@@ -234,6 +234,8 @@
     margin-top: 0;
 }
 
+/* city-2 routes */
+
 .city-2 .route > li {
     background-image: url(../img/search-result-2-line.png);
 }
@@ -244,6 +246,11 @@
 
 .city-2 .route > li.exit:before {
     background-image: url(../img/search-result-2-circle.png);
+}
+
+.city-2 .route > li.line-7,
+.city-2 .route > li.to-line-7 {
+    background-position: 0 -1200px;
 }
 
 ul.available {


### PR DESCRIPTION
Re #107

the problem with the background position for search-result-2-line.png - it is much smaller than the search-result-1-line.png, but the background-position is the same. I fixed only for line №7, but it might not work for some other lines, too.
